### PR TITLE
Nitpick suggestion: move clone and cd to one line.

### DIFF
--- a/content/docs/overview/real-world-example.md
+++ b/content/docs/overview/real-world-example.md
@@ -27,8 +27,7 @@ toc: true
 First clone the example repo
 
 ```bash
-git clone https://github.com/metalbear-co/nodejs-example.git
-cd nodejs-example
+git clone https://github.com/metalbear-co/nodejs-example.git && cd nodejs-example
 ```
 
 ### Setup Cluster


### PR DESCRIPTION
That way the reader can click the copy button in the website and paste the command as-is.