### PR TITLE
Adding agent image registry-path to faq.md

### DIFF
--- a/content/docs/overview/faq.md
+++ b/content/docs/overview/faq.md
@@ -26,7 +26,9 @@ mirrord also has specific support for the following languages that don't use lib
 
 ## Does mirrord install anything on the cluster?
 
-No, mirrord doesn't install anything on the cluster, nor does it have any persistent state. It does spawn a short-living pod/container to run the proxy, which is automatically removed when mirrord exits.
+No, mirrord doesn't install anything on the cluster, nor does it have any persistent state. It does spawn a short-living pod/container to run the proxy, which is automatically removed when mirrord exits. 
+
+If you have any restrictions for pulling external images inside your cluster, you have to allow pulling of ghcr.io/metalbear-co/mirrord image.
 
 ## How is mirrord different from Telepresence?
 


### PR DESCRIPTION
In our cluster, we have a policy to disallow pulling of external images which are not explicitly allowed. That is why the agent doesn't work at first. For me, it was not so easy to find out the registry-path of the agent-image. That's why I want to add this at minimum to the FAQ.

For a possible Troubleshooting section:
I found this out by running `kubectl get events`:
```
LAST SEEN   TYPE      REASON         OBJECT                         MESSAGE
4m31s       Warning   FailedCreate   job/mirrord-agent-nwraf7nolp   Error creating: admission webhook denied the request: [...] Container image ghcr.io/metalbear-co/mirrord:3.1.2 for container mirrord-agent has not been allowed.
```