### PR TITLE
faq and shortcodes

### DIFF
--- a/content/docs/overview/faq.md
+++ b/content/docs/overview/faq.md
@@ -46,7 +46,7 @@ There are currently two known cases where mirrord cannot load into the applicati
    [SIP](https://en.wikipedia.org/wiki/System_Integrity_Protection) (the application you are developing wouldn't be,
    but the binary that is used to execute it, e.g. `bash` for a bash script, might be protected), mirrord would not be
    able to load into it. If that is the case, you could try
-   [running mirrord from the command line](https://mirrord.dev/docs/overview/quick-start/#cli-tool) (where SIP
+   [running mirrord from the command line]({{< ref "/docs/overview/quick-start/#cli-tool" >}} "cli tool getting started") (where SIP
    bypassing is already implemented) instead of in the IDE. Alternatively, you could try copying the binary you're
    trying to run to an unprotected directory (e.g. anywhere in your home directory), changing the run configuration
    to use the copy instead of the original binary, and trying again. If it still doesn't work, also remove the signature
@@ -81,3 +81,15 @@ mirrord can be a great alternative to Telepresence. The main differences are:
 * mirrord can be run through one of our IDE extensions: we support [IntelliJ](https://plugins.jetbrains.com/plugin/19772-mirrord) and [VS Code](vscode:extension/MetalBear.mirrord).
 
 More details can be found in this [GitHub discussion.](https://github.com/metalbear-co/mirrord/discussions/154#discussioncomment-2972127)
+
+## Is mirrord free?
+
+mirrord is free and open source (MIT License).
+Our paid offering include an operator that adds a control plane for mirrord and is used automatically by mirrord when found.
+More details on what the operator provides can be read [here]({{< ref "/docs/teams/introduction" >}} "mirrord for Teams")
+
+## I can't create priveleged container in my cluster
+
+mirrord works by creating an agent in the remote cluster, that accesses another pod's namespaces (see more about it [here.](https://metalbear.co/blog/getting-started-with-ephemeral-containers/)).
+If you can't do that, we suggest considering using our operator. The operator is provided as part of [mirrord for Teams]({{< ref "/docs/teams/introduction" >}} "mirrord for Teams") and lets you provide users access to using mirrord, instead of creating priveleged pods. You'd still need to provide the operator the ability to spawn
+priveleged pods, but now only *it* will be able to do it, instead of any user.

--- a/content/docs/overview/quick-start.md
+++ b/content/docs/overview/quick-start.md
@@ -76,7 +76,7 @@ To use extension, click the 'Enable mirrord' button in the status bar at the bot
 #### Configuration
 
 The VS Code extension reads its configuration from the following file: `<project-path>/.mirrord/mirrord.json`. You can also prepend a prefix, e.g. `my-config.mirrord.json`, or use .toml or .yaml format.
-Configuration options are listed [here](https://mirrord.dev/docs/overview/configuration/). The configuration file also supports autocomplete when edited in VS Code when the extension is installed.
+Configuration options are listed [here]({{< ref "/docs/overview/configuration" >}} "configuration"). The configuration file also supports autocomplete when edited in VS Code when the extension is installed.
 
 ### IntelliJ Plugin
 
@@ -91,4 +91,4 @@ To use extension, click the mirrord icon in the Navigation Toolbar at the top ri
 #### Configuration
 
 The IntelliJ plugin reads its configuration from the following file: `<project-path>/.mirrord/mirrord.json`. You can also prepend a prefix, e.g. `my-config.mirrord.json`, or use .toml or .yaml format.
-Configuration options are listed [here](https://mirrord.dev/docs/overview/configuration/).
+Configuration options are listed [here]({{< ref "/docs/overview/configuration" >}} "configuration").

--- a/content/docs/overview/real-world-example.md
+++ b/content/docs/overview/real-world-example.md
@@ -18,7 +18,7 @@ toc: true
 
 ### Prerequisites
 
-* [mirrord](https://mirrord.dev/)
+* [mirrord][here]({{< ref "/" >}} "mirrord")
 * Available Kubernetes Cluster
   * Note: at the moment, because it uses `kubectl port-forward`, the tutorial does not support clusters with a service mesh like Istio or linkerd.
 * [NodeJS](https://nodejs.org/en/) + [Yarn](https://www.npmjs.com/package/yarn)

--- a/content/docs/reference/targets/index.md
+++ b/content/docs/reference/targets/index.md
@@ -110,5 +110,5 @@ Moreover, you should make sure [the environment variable used to specify a targe
 isn't set (or is set to an empty value).
 
 > **Note:** In order to set the namespace the agent is going to be created in, set the agent namespace, not the
-> target namespace. That value can be set via the [`agent.namespace` configuration file field](https://mirrord.dev/docs/overview/configuration/#agent-namespace), the `-a` CLI argument,
+> target namespace. That value can be set via the [`agent.namespace` configuration file field]({{< ref "/docs/overview/configuration/#agent-namespace" >}} "agent namespace configuration"), the `-a` CLI argument,
 > or the `MIRRORD_AGENT_NAMESPACE` environment variable.


### PR DESCRIPTION
change
- use shortcodes in some places instead of perma url

added to faq

- is mirrord free?
- I can't create privileged container in my cluster
