### PR TITLE
fix FAQ link at the top of the page.

### DIFF
--- a/config/_default/menus/menus.yaml
+++ b/config/_default/menus/menus.yaml
@@ -18,7 +18,7 @@ main:
   parent: resources
 - identifier: FAQ
   name: FAQ
-  url: "/docs/overview/faq"
+  url: "/docs/faq/general"
   weight: 300
   parent: resources
 - identifier: teams


### PR DESCRIPTION
Fix #228

The FAQ page does not exist anymore so that link did not work.
Linking to FAQ/general instead.