### PR TITLE
fix link from security FAQ to policies page

### DIFF
--- a/content/docs/managing-mirrord/security/index.md
+++ b/content/docs/managing-mirrord/security/index.md
@@ -153,5 +153,5 @@ If the user doesn't have `get` access to the targets, then they won't be able to
 
 ## How can I prevent users in my team from stealing traffic from a target?
 
-You can define [policies](/docs/teams/policies/) that prevent stealing (or only prevent stealing without setting a
+You can define [policies](/docs/managing-mirrord/policies/) that prevent stealing (or only prevent stealing without setting a
 filter) for selected targets. Let us know if there are more features you would like to be able to limit using policies.


### PR DESCRIPTION
At some point the structure of the website was changed and this link was not updated, so it just leads back to the main page.