### PR TITLE
chore: `stealer` -> `steal`

### DIFF
--- a/content/docs/reference/configuration.md
+++ b/content/docs/reference/configuration.md
@@ -803,7 +803,7 @@ Steal only traffic that matches the
 Ports to ignore when mirroring/stealing traffic, these ports will remain local.
 
 Can be especially useful when
-[`feature.network.incoming.mode`](#feature-network-incoming-mode) is set to `"stealer"
+[`feature.network.incoming.mode`](#feature-network-incoming-mode) is set to `"steal"
 `, and you want to avoid redirecting traffic from some ports (for example, traffic from
 a health probe, or other heartbeat-like traffic).
 


### PR DESCRIPTION
chore: `stealer` -> `steal`

`stealer` doesn't seem to be a valid option.

![image](https://github.com/metalbear-co/mirrord.dev/assets/58607256/03ccf048-df4b-4741-b899-0bb0d64e1e9f)
