### PR TITLE
doc: Load symbol table and debug information with `go run`

### DIFF
--- a/content/docs/faq/common-issues.md
+++ b/content/docs/faq/common-issues.md
@@ -22,8 +22,9 @@ There are currently two known cases where mirrord cannot load into the applicati
    linked in order to run them with mirrord.
    With Go programs, for example, it is as simple as adding `import "C"` to your program code.
    If you don't want to add an import to your Go program, you can alternatively build a dynamically linked binary using `go build -ldflags='-linkmode external'`. In VSCode, this can be done by adding `"buildFlags": "-ldflags='-linkmode external'"` to your `launch.json`.
-   On Linux, using `go run` is not possible at the moment - please follow [this issue](https://github.com/metalbear-co/mirrord/issues/1922) for updates.
-2. If you are running mirrord on MacOS and the executable you are running is protected by
+   
+   On Linux, append `-ldflags="-s=false"` to instruct `go run` not to omit the symbol table and debug information required by mirrord.
+3. If you are running mirrord on MacOS and the executable you are running is protected by
    [SIP](https://en.wikipedia.org/wiki/System_Integrity_Protection) (the application you are developing wouldn't be,
    but the binary that is used to execute it, e.g. `bash` for a bash script, might be protected), mirrord might have trouble loading into it (mirrord can generally bypass SIP, but there are still some unhandled edge cases). If that is the case, you could try copying the binary you're trying to run to an unprotected directory (e.g. anywhere in your home directory), changing the IDE run configuration or the CLI
    to use the copy instead of the original binary, and trying again. If it still doesn't work, also remove the signature


### PR DESCRIPTION
Related to https://github.com/metalbear-co/mirrord/issues/1922