### PR TITLE
Change homepage title to hardcoded and change page subtitles

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,5 +1,5 @@
 ---
-title: Faster, Simpler Kubernetes Development
+title: mirrord
 baseURL: https://mirrord.dev/
 languageCode: en-US
 defaultContentLanguage: en

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,4 @@
 ---
-title : "mirrord"
 description: "mirrord lets you run local processes in the real-time context of your k8s environment, and test continuously in the cloud going through CI and deployment."
 lead: "mirrord lets you run local processes in the real-time context of your k8s environment, and test continuously in the cloud going through CI and deployment."
 date: 2020-10-06T08:47:36+00:00

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -1,12 +1,14 @@
-<head>    
+<head>
     <meta charset="utf-8">
     {{- hugo.Generator }}
     {{ if and (.Site.Params.alert) (ne .Section "docs") }}
-        {{ partial "header/alert.html" . }}
+    {{ partial "header/alert.html" . }}
     {{ end -}}
-    <title>{{ if .Title }}{{ .Title }} | {{ end }}{{ site.Title }}</title>
+    <title>{{ if .Title }}{{ .Title }} | {{ site.Title }}{{ else }}mirrord | Faster, Simpler Kubernetes Development{{
+        end }}</title>
     <meta name="author" content="{{ site.Params.author }}">
-    <meta name="description" content="{{ with .Params.description }} {{.}} {{else}} {{ with site.Params.description }} {{.}} {{end}} {{end}}">
+    <meta name="description"
+        content="{{ with .Params.description }} {{.}} {{else}} {{ with site.Params.description }} {{.}} {{end}} {{end}}">
     {{- "<!-- mobile responsive meta -->" | safeHTML}}
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
     <!-- favicon -->
@@ -19,7 +21,7 @@
     {{- partial "site_head_seo.html" . }}
 
     <script defer data-domain="mirrord.dev" src="https://plausible.io/js/script.hash.outbound-links.js"></script>
-    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+    <script>window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
     <script src="/pagefind/pagefind-ui.js"></script>
 


### PR DESCRIPTION
Closes #324 

homepage title: "mirrord | Faster, Simpler Kubernetes Development"
other page titles: "{Page Title} | mirrord"