### PR TITLE
fix typo in quick start

### DIFF
--- a/content/docs/overview/quick-start.md
+++ b/content/docs/overview/quick-start.md
@@ -190,7 +190,7 @@ Note that, by default, the following features are also enabled:
 1. Environment variables from the remote target will be imported into your local process
 2. When reading files, your local process will read them from the remote target
 3. DNS resolution for your local process will happen on the remote target
-4. Outgoing traffic sent by your local process will be sent out from the remote target instead, and the response will be sent back to your locall process
+4. Outgoing traffic sent by your local process will be sent out from the remote target instead, and the response will be sent back to your local process
 
 We find that this configuration works for a lot of use cases, but if you'd like to change it, please read about available options in the [configuration](/docs/reference/configuration/).
 


### PR DESCRIPTION
Hey! Was going through the quick start and found a typo. 

Also had some suggestions for the quick start:
- I found the [Operator section](https://mirrord.dev/docs/overview/quick-start/#operator) confusing as I wasn't sure what the operator does. It was only after reading the "mirrord for Teams" page did I get what the goal was. I'd recommend linking to that page in the intro para for the Operator. Ideally I think separating these two out would make for a better reading experience for developers. 
- Currently the guide requires the reader to create a sample app (or use their production app) to be able to try out mirrord. Having a sample app hosted on GitHub which the users could just clone to try the project out would be really helpful.

