### PR TITLE
typo in quick-start.md

### DIFF
--- a/content/docs/overview/quick-start.md
+++ b/content/docs/overview/quick-start.md
@@ -148,7 +148,7 @@ Then download the accompanying `values.yaml`:
 curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator/values.yaml --output values.yaml
 ```
 
-Set \`license.key\` to your key.
+Set `license.key` to your key.
 
 Finally, install the chart:
 ```bash


### PR DESCRIPTION
I think the intent was to have `license.key` but currently it's not being show in a codeblock (see attached image)

![Screenshot 2025-03-19 at 8 18 41 PM](https://github.com/user-attachments/assets/54c84cb8-fe93-4501-a0c0-1be2026610f9)
